### PR TITLE
feat: wrap data in a `GitHubResponse` struct

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@ mod no_content_request_builder;
 mod personal_access_token;
 mod request;
 mod request_builder;
+mod response;
 
 pub use api_config::*;
 pub use app_authorization::*;
@@ -17,3 +18,4 @@ pub use no_content_request_builder::*;
 pub use personal_access_token::*;
 pub use request::*;
 pub use request_builder::*;
+pub use response::*;

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -1,0 +1,11 @@
+use reqwest::{header::HeaderMap, StatusCode, Url, Version};
+
+#[derive(Clone)]
+pub struct GitHubResponse<ResponseData> {
+  pub data: ResponseData,
+  pub headers: HeaderMap,
+  pub status: StatusCode,
+  pub version: Version,
+  pub content_length: Option<u64>,
+  pub url: Url,
+}


### PR DESCRIPTION
### Description

This provides access to the `reqwest::Response` metadata.

Fixes #6